### PR TITLE
Update supplyAndDemand.lua

### DIFF
--- a/supplyAndDemand.lua
+++ b/supplyAndDemand.lua
@@ -283,6 +283,10 @@ local function setFillTypeDemandTitles()
       populateMissingDataPoints()
     end
 
+    if string.find(fillType.title, "%s%p([-%d+]+)%p+") ~= nil then
+      fillType.title = string.gsub(fillType.title, "%s%p([-%d+]+)%p+", "", 2)
+    end
+    
     fillType.defaultTitle = fillType.title
     fillType.title = string.format(
       '%s (%d%%)',


### PR DESCRIPTION
Fix for endlessly appending the supply factor % at the end of fillType.title, each time the Prices pages was opened